### PR TITLE
Resolves #9 - removed references to X-Userinfo and fixed X-UserGroup reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ From version 1.2.0 the file IP2LOCATION-LITE-DB5.BIN is no longer part of the do
 ## Added
 - IP2Location's file location as variable
 
+## Changed
+- Removed adding X-Userinfo from response headers
+
 # [1.2.1] - 2021-10-29
 
 ## Fixed

--- a/incore_auth/app.py
+++ b/incore_auth/app.py
@@ -281,16 +281,10 @@ def verify_token():
     elif request.cookies.get('Authorization') is not None:
         response.headers['Authorization'] = unquote_plus(request.cookies['Authorization'])
 
-    # TODO this need checking, does this allow me to impersonate anybody?
-    if request.headers.get('X-UserInfo') is not None:
-        response.headers['X-UserInfo'] = request.headers.get('x-UserInfo')
-    elif request.cookies.get('x-UserInfo') is not None:
-        response.headers['X-UserInfo'] = request.headers.get('x-UserInfo')
-
     if request.headers.get('X-UserGroup') is not None:
         response.headers['X-UserGroup'] = request.headers.get('x-UserGroup')
-    elif request.cookies.get('x-UserInfo') is not None:
-        response.headers['X-UserGroup'] = request.headers.get('x-UserGroup')
+    elif request.cookies.get('X-UserGroup') is not None:
+        response.headers['X-UserGroup'] = request.cookies['X-UserGroup']
 
     return response
 


### PR DESCRIPTION
X-Userinfo doesn't need to be in the response headers with a recent fix to DataWolf to parse x-auth-userinfo. I also fixed a typo in adding X-UserGroup to the response header.