### PR TITLE
return userobject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ From version 1.2.0 the file IP2LOCATION-LITE-DB5.BIN is no longer part of the do
 
 ## Added
 - New user default usage to zero [#38](https://github.com/IN-CORE/incore-auth/issues/38)
+- Return a user object that contains username, fullname, email, groups and roles.
 
 
 # [1.6.0] - 2023-03-14

--- a/incore_auth/app.py
+++ b/incore_auth/app.py
@@ -282,9 +282,10 @@ def request_userinfo(request_info):
         return
 
     # get name of user
-    request_info["firstname"] = access_token["given_name"]
-    request_info["lastname"] = access_token["family_name"]
-    request_info["fullname"] = access_token["name"]
+    request_info["firstname"] = access_token.get("given_name", "")
+    request_info["lastname"] = access_token.get("family_name", "")
+    request_info["fullname"] = access_token.get("name", "")
+    request_info["email"] = access_token.get("email", "")
 
     # retrieve the groups the user belongs to from access token
     request_info['username'] = access_token["preferred_username"]
@@ -356,6 +357,7 @@ def verify_token():
         "firstname": "",
         "lastname": "",
         "fullname": "",
+        "email": "",
         "method": request.method,
         "url": request.path,
         "resource": "",
@@ -404,19 +406,23 @@ def verify_token():
     # everything is ok
     user_info = {"preferred_username": request_info['username']}
     group_info = {"groups": request_info['groups']}
+    user_object = {
+        "username": request_info['username'],
+        "email": request_info['email'],
+        "fullname": request_info['fullname'],
+        "groups": request_info['groups'],
+        "roles": request_info['roles'],
+    }
+
     response = Response(status=200)
     response.headers['X-Auth-UserInfo'] = json.dumps(user_info)
     response.headers['X-Auth-UserGroup'] = json.dumps(group_info)
+    response.headers['X-Auth-User'] = json.dumps(user_object)
 
     if request.headers.get('Authorization') is not None:
         response.headers['Authorization'] = unquote_plus(request.headers['Authorization'])
     elif request.cookies.get('Authorization') is not None:
         response.headers['Authorization'] = unquote_plus(request.cookies['Authorization'])
-
-    if request.headers.get('X-Auth-UserGroup') is not None:
-        response.headers['X-Auth-UserGroup'] = request.headers.get('X-Auth-UserGroup')
-    elif request.cookies.get('X-Auth-UserGroup') is not None:
-        response.headers['X-Auth-UserGroup'] = request.cookies['X-Auth-UserGroup']
 
     return response
 


### PR DESCRIPTION
a new header X-Auth-User is returned that contains all the user information

the auth-user contains all in the information from the other two headers, as well as the fullname, email as well.

This also removes the copying of the auth username at the very end of the code, just before the result is returned. If this is/was used for local testing where we could set the users groups, this will no longer work. This is a security issue and should not be used.