### PR TITLE
Added Geoserver to incore-auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ From version 1.2.0 the file IP2LOCATION-LITE-DB5.BIN is no longer part of the do
 - Geoserver is added to incore-auth [#46](https://github.com/IN-CORE/incore-auth/issues/46)
 - Project service is added to incore-auth [#47](https://github.com/IN-CORE/incore-auth/issues/47)
 
+
 # [1.7.0] - 2023-06-14
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ From version 1.2.0 the file IP2LOCATION-LITE-DB5.BIN is no longer part of the do
 - Geoserver is added to incore-auth [#46](https://github.com/IN-CORE/incore-auth/issues/46)
 - Project service is added to incore-auth [#47](https://github.com/IN-CORE/incore-auth/issues/47)
 
-
 # [1.7.0] - 2023-06-14
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 From version 1.2.0 the file IP2LOCATION-LITE-DB5.BIN is no longer part of the docker image and will need to be downloaded (after registration) from [ip2location](https://lite.ip2location.com/database/ip-country?lang=en_US) and be placed in /srv/incore_auth.
 
+# Unreleased
+
+# Added
+- Geoserver is added to incore-auth [#46](https://github.com/IN-CORE/incore-auth/issues/46)
+- Project service is added to incore-auth [#47](https://github.com/IN-CORE/incore-auth/issues/47)
+
 # [1.7.0] - 2023-06-14
 
 ## Added

--- a/incore_auth/config.json
+++ b/incore_auth/config.json
@@ -1,6 +1,6 @@
 {
-    "PROTECTED_RESOURCES": ["data", "dfr3", "hazard", "space", "semantics", "maestro", "datawolf", "plotting", "hub"],
-    "TRACKED_RESOURCES": ["data", "dfr3", "hazard", "space", "semantics", "maestro", "datafwolf", "plotting", "playbook", "frontpage", "geoserver", "doc", "hub", "lab", "auth", "DFR3Viewer", "DataViewer", "HazardViewer", "jupyterhub"],
-    "GROUPS": {"incore_user": ["data", "dfr3", "hazard", "space", "semantics", "maestro", "datawolf", "plotting", "hub"]},
-    "ROLES": {"incore_user": ["data", "dfr3", "hazard", "space", "semantics", "maestro", "datawolf", "plotting", "hub"]}
+    "PROTECTED_RESOURCES": ["data", "dfr3", "hazard", "space", "semantics", "project", "maestro", "datawolf", "plotting", "hub", "geoserver"],
+    "TRACKED_RESOURCES": ["data", "dfr3", "hazard", "space", "semantics", "project", "maestro", "datafwolf", "plotting", "playbook", "frontpage", "geoserver", "doc", "hub", "lab", "auth", "DFR3Viewer", "DataViewer", "HazardViewer", "jupyterhub"],
+    "GROUPS": {"incore_user": ["data", "dfr3", "hazard", "space", "semantics", "project", "maestro", "datawolf", "plotting", "hub"]},
+    "ROLES": {"incore_user": ["data", "dfr3", "hazard", "space", "semantics", "project", "maestro", "datawolf", "plotting", "hub"]}
 }

--- a/incore_auth/config.json
+++ b/incore_auth/config.json
@@ -1,6 +1,6 @@
 {
     "PROTECTED_RESOURCES": ["data", "dfr3", "hazard", "space", "semantics", "project", "maestro", "datawolf", "plotting", "hub", "geoserver"],
     "TRACKED_RESOURCES": ["data", "dfr3", "hazard", "space", "semantics", "project", "maestro", "datafwolf", "plotting", "playbook", "frontpage", "geoserver", "doc", "hub", "lab", "auth", "DFR3Viewer", "DataViewer", "HazardViewer", "jupyterhub"],
-    "GROUPS": {"incore_user": ["data", "dfr3", "hazard", "space", "semantics", "project", "maestro", "datawolf", "plotting", "hub"]},
-    "ROLES": {"incore_user": ["data", "dfr3", "hazard", "space", "semantics", "project", "maestro", "datawolf", "plotting", "hub"]}
+    "GROUPS": {"incore_user": ["data", "dfr3", "hazard", "space", "semantics", "project", "maestro", "datawolf", "plotting", "hub", "geoserver"]},
+    "ROLES": {"incore_user": ["data", "dfr3", "hazard", "space", "semantics", "project", "maestro", "datawolf", "plotting", "hub", "geoserver"]}
 }

--- a/incore_auth/config.json
+++ b/incore_auth/config.json
@@ -1,6 +1,6 @@
 {
-    "PROTECTED_RESOURCES": ["data", "dfr3", "hazard", "space", "semantics", "project", "maestro", "datawolf", "plotting", "hub", "geoserver"],
+    "PROTECTED_RESOURCES": ["data", "dfr3", "hazard", "space", "semantics", "project", "maestro", "datawolf", "plotting", "hub", "geoserver", "geoserver/web"],
     "TRACKED_RESOURCES": ["data", "dfr3", "hazard", "space", "semantics", "project", "maestro", "datafwolf", "plotting", "playbook", "frontpage", "geoserver", "doc", "hub", "lab", "auth", "DFR3Viewer", "DataViewer", "HazardViewer", "jupyterhub"],
-    "GROUPS": {"incore_user": ["data", "dfr3", "hazard", "space", "semantics", "project", "maestro", "datawolf", "plotting", "hub", "geoserver"]},
-    "ROLES": {"incore_user": ["data", "dfr3", "hazard", "space", "semantics", "project", "maestro", "datawolf", "plotting", "hub", "geoserver"]}
+    "GROUPS": {"incore_user": ["data", "dfr3", "hazard", "space", "semantics", "project", "maestro", "datawolf", "plotting", "hub", "geoserver", "geoserver/web"]},
+    "ROLES": {"incore_user": ["data", "dfr3", "hazard", "space", "semantics", "project", "maestro", "datawolf", "plotting", "hub", "geoserver", "geoserver/web"]}
 }


### PR DESCRIPTION
Added geoserver and project url to auths config file. Also, geoserver is now going forward to middleware via traefik but it is not in this PR. It is recorded in values-geoserver-*.yaml file located in box folder

This is also deployed in dev now so you can try to access geoserver by going to https://incore-dev.ncsa.illinois.edu/geoserver/web/ You should be able to go there after you login to incore frontend

Also, please test if the data viewer shows the maps correctly